### PR TITLE
BoundsError if f[1] did not exist

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -41,15 +41,18 @@ function link_bundled_dylibs()
 
     # We already have these dylibs loaded; let's find them and symlink them
     for d in bundled_dylibs
-        f = filter( x->contains(x,d), shlibs)[1]
-        symlink = abspath(joinpath(gfortran_cellar,"lib",basename(f)))
-        if !isfile(symlink)
-            run(`ln -fs $f $symlink`)
-        end
+        f = filter( x->contains(x,d), shlibs)
+        if !(isempty(f))
+            f=f[1]
+            symlink = abspath(joinpath(gfortran_cellar,"lib",basename(f)))
+            if !isfile(symlink)
+                run(`ln -fs $f $symlink`)
+            end
 
-        symlink = abspath(joinpath(gfortran_cellar,"gfortran","lib",basename(f)))
-        if !isfile(symlink)
-            run(`ln -fs $f $symlink`)
+            symlink = abspath(joinpath(gfortran_cellar,"gfortran","lib",basename(f)))
+            if !isfile(symlink)
+                run(`ln -fs $f $symlink`)
+            end
         end
     end
 


### PR DESCRIPTION
Fixed a bug in case of filter() does not return anything and f is empty. 
