### PR TITLE
Improve load time

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -37,7 +37,7 @@ properly so that packages being installed can find their binaries.
 """
 function __init__()
     # Let's see if Homebrew is installed.  If not, let's do that first!
-    install_brew()
+    isdir(brew_prefix) || install_brew()
 
     # Update environment variables such as PATH, DL_LOAD_PATH, etc...
     update_env()


### PR DESCRIPTION
I've moved the install call out of init, assuming that it's only needed at build time when the package is installed. This is good for package load time (~0.5s to ~10x less).

cc @staticfloat, I could use someone more expert to make sure this is correct.