### PR TITLE
Install `git` more reliably when we need it

### DIFF
--- a/src/private_API.jl
+++ b/src/private_API.jl
@@ -51,7 +51,7 @@ function install_brew()
         add("cctools")
     end
 
-    if !installed("git")
+    if !git_installed() && !installed("git")
         # If we don't have a git available, install it now
         add("git")
     end
@@ -142,6 +142,14 @@ update at our own pace along with them.
 """
 function update_tag(;verbose::Bool=false)
     global BREW_STABLE_SHA, brew_prefix
+
+    # If a recent enough version of git is not installed, then install our own
+    # This is necessary because some people do not have git installed but already
+    # have Homebrew installed, and the check up above during install_brew()
+    # doesn't run every time
+    if !git_installed()
+        add("git")
+    end
 
     git_path = joinpath(brew_prefix, "bin", "git")
     if verbose

--- a/src/util.jl
+++ b/src/util.jl
@@ -101,6 +101,19 @@ function git_installed()
         return false
     end
 
+    # check that the git version is at least 2.0.0.0.  We may end up
+    # tightening these bounds a little bit in the future, so parse
+    # out the full git version
+    m = match(r"^git version ([\d\.]+) ", readchomp(`git --version`))
+    if m === nothing
+        return false
+    end
+    gitver = [parse(Int64, x) for x in split(m.captures[1], ".")]
+
+    if gitver[1] < 2
+        return false
+    end
+
     # If we made it through the gauntlet, succeed!
     return true
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -87,6 +87,8 @@ end
 `git_installed()`
 
 Checks whether `git` is truly installed or not, dealing with stubs in /usr/bin
+Also ensure that the version is new enough (e.g. >= 2.0.0.0) that it will work
+with `git fetch --unshallow` on Homebrew.
 """
 function git_installed()
     gitpath = readchomp(`which git`)


### PR DESCRIPTION
This fixes the problems with Homebrew installations that are NOT from-scratch