### PR TITLE
Better `__init__()`-time installation checking

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -37,7 +37,7 @@ properly so that packages being installed can find their binaries.
 """
 function __init__()
     # Let's see if Homebrew is installed.  If not, let's do that first!
-    isdir(brew_prefix) || install_brew()
+    (isdir(brew_prefix) && isdir(tappath)) || install_brew()
 
     # Update environment variables such as PATH, DL_LOAD_PATH, etc...
     update_env()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,8 +62,9 @@ end
 # Test that we can probe for bottles properly
 @test Homebrew.has_bottle("ack") == false
 @test Homebrew.has_bottle("cairo") == true
+# I will be a very happy man the day this test starts to fail
 @test Homebrew.has_relocatable_bottle("cairo") == false
-@test Homebrew.has_relocatable_bottle("fontconfig") == true
+@test Homebrew.has_relocatable_bottle("staticfloat/juliadeps/libgfortran") == true
 @test Homebrew.json(pkgconfig)["name"] == "pkg-config"
 
 # Test that has_bottle knows which OSX version we're running on.


### PR DESCRIPTION
This should address the issues people have been having recently with improperly initialized Homebrew installations.