### PR TITLE
Add High Sierra to the list of macOS versions.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -638,7 +638,8 @@ function osx_version_string()
         "10.9" => "mavericks",
         "10.10" => "yosemite",
         "10.11" => "el_capitan",
-        "10.12" => "sierra"
+        "10.12" => "sierra",
+        "10.13" => "high_sierra"
     )[OSX_VERSION[1]]
 end
 


### PR DESCRIPTION
Just a small edit to prevent installation abort when running on macOS High Sierra.
After applying the patch, you get the usual warnings from Homebrew (WARNING: The following packages do not have relocatable bottles, installation may fail!) until they add the corresponding bottles, but in my case everything went smooth using the automatic compilation fallback.

Here is an example output when trying to install `Nettle`:

```
v0.6.0> Pkg.build("Nettle")
INFO: Building Homebrew
INFO: Building Nettle
WARNING: Compat.KERNEL is deprecated.
  likely near /Users/tamasgal/.julia/v0.6/Nettle/deps/build.jl:39
WARNING: Compat.KERNEL is deprecated.
  likely near /Users/tamasgal/.julia/v0.6/Nettle/deps/build.jl:39
in can_use at /Users/tamasgal/.julia/v0.6/Homebrew/src/bindeps_integration.jl
WARNING: Compat.KERNEL is deprecated.
  likely near /Users/tamasgal/.julia/v0.6/Nettle/deps/build.jl:39
in package_available at /Users/tamasgal/.julia/v0.6/Homebrew/src/bindeps_integration.jl
===============================[ ERROR: Nettle ]================================

LoadError: KeyError: key "10.13" not found
while loading /Users/tamasgal/.julia/v0.6/Nettle/deps/build.jl, in expression starting on line 39

================================================================================

================================[ BUILD ERRORS ]================================

WARNING: Nettle had build errors.

 - packages with build errors remain installed in /Users/tamasgal/.julia/v0.6
 - build the package(s) and all dependencies with `Pkg.build("Nettle")`
 - build a single package by running its `deps/build.jl` script

================================================================================
```