### PR TITLE
WIP: Bump stable SHA

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -651,8 +651,12 @@ end
 Checks if a given formula has a bottle at all
 """
 function has_bottle(name::AbstractString)
-    return haskey(json(name)["bottle"], "stable") &&
-           haskey(json(name)["bottle"]["stable"]["files"], osx_version_string())
+    return try
+            haskey(json(name)["bottle"], "stable") &&
+            haskey(json(name)["bottle"]["stable"]["files"], osx_version_string())
+        catch
+            false
+        end
 end
 
 """

--- a/src/private_API.jl
+++ b/src/private_API.jl
@@ -15,7 +15,7 @@ const auto_tappath = joinpath(brew_prefix,"Library","Taps","staticfloat","homebr
 # Where we download brew from
 const BREW_URL = "https://github.com/Homebrew/brew"
 const BREW_BRANCH = "master"
-const BREW_STABLE_SHA = "6a912c369125caca5e1e3929e942bbb946ce6367"
+const BREW_STABLE_SHA = "2b83463091513826127c14acae81a7c354dfce69"
 
 """
 `install_brew()`


### PR DESCRIPTION
@staticfloat I'm trying to fix #257 but I still get the following errors:

```
(v1.1) pkg> test Homebrew
...
[ Info: Translation should pass because we just deleted libgfortran from translation cache:
translation: beginning for staticfloat/juliadeps/libgfortran
translation: bailing because staticfloat/juliadeps/libgfortran has no bottles
Test Failed at /Users/jonas/.julia/dev/Homebrew/test/runtests.jl:89
  Expression: Homebrew.translate_formula("staticfloat/juliadeps/libgfortran"; verbose=true) == "staticfloat/juliatranslated/libgfortran"
   Evaluated: "staticfloat/juliadeps/libgfortran" == "staticfloat/juliatranslated/libgfortran"
ERROR: LoadError: There was an error during testing
in expression starting at /Users/jonas/.julia/dev/Homebrew/test/runtests.jl:89
ERROR: Package Homebrew errored during testing
```

Naively editing `~/.julia/dev/Homebrew/deps/usr/Library/Taps/staticfloat/homebrew-juliadeps/libgfortran.rb` to also fake the Mojave bottle leads to a failure further down the line, as there is no such file:
```
(v1.1) pkg> test Homebrew
...
[ Info: Translation should fail because libgfortran has already been translated:
translation: beginning for staticfloat/juliadeps/libgfortran
translation: bailing becuase staticfloat/juliadeps/libgfortran is already available in tap staticfloat/juliatranslated
runtime_deps: String[]
sorted_deps: AbstractString[]
build_deps only: AbstractString[]
translation: beginning for staticfloat/juliadeps/libgfortran
translation: successfully finished for staticfloat/juliadeps/libgfortran
Warning: --ignore-dependencies is an unsupported Homebrew developer flag!
Adjust your PATH to put any preferred versions of applications earlier in the
PATH rather than using this unsupported flag!

==> Installing libgfortran from staticfloat/juliatranslated
==> Downloading https://juliabottles.s3.amazonaws.com/libgfortran-7.2.mojave.bottle.tar.gz
/usr/bin/curl -q --show-error --user-agent Homebrew/2.1.7\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.14.5\)\ curl/7.54.0 --fail --location --remote-time --continue-at 0 --output /Users/jonas/Library/Caches/Homebrew.jl/downloads/b4f0c111cabb0af3cb56a63b4bb7e2a4de48cdcd03c7bf45c9de2d106991aa97--libgfortran-7.2.mojave.bottle.tar.gz.incomplete https://juliabottles.s3.amazonaws.com/libgfortran-7.2.mojave.bottle.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Download failed: https://juliabottles.s3.amazonaws.com/libgfortran-7.2.mojave.bottle.tar.gz
```
Building from source also fails:
```
...
Warning: Bottle installation failed: building from source.
/usr/bin/sandbox-exec -f /private/tmp/homebrew20190711-18896-zwedst.sb nice /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby -W0 -I /Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-cobertura-1.3.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ruby-macho-2.2.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-rspec-1.33.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-performance-1.4.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rubocop-0.72.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unicode-display_width-1.6.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ruby-progressbar-1.10.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-wait-0.0.9/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-retry-0.6.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-its-1.3.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-3.8.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-mocks-3.8.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-expectations-3.8.4/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-core-3.8.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rspec-support-3.8.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ronn-0.7.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rdiscount-2.2.0.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/rdiscount-2.2.0.1:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/rainbow-3.0.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/plist-3.5.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parser-2.6.3.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parallel_tests-2.29.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/parallel-1.17.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mustache-1.1.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mechanize-2.7.6/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/webrobots-0.1.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ntlm-http-0.1.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/nokogiri-1.10.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/nokogiri-1.10.3:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mini_portile2-2.4.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/net-http-persistent-3.0.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/net-http-digest_auth-1.4.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mime-types-3.2.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/mime-types-data-3.2019.0331/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/jaro_winkler-1.5.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/jaro_winkler-1.5.3:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/http-cookie-1.0.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/hpricot-0.8.6/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/hpricot-0.8.6:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/domain_name-0.5.20180417/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unf-0.1.4/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/unf_ext-0.0.7.6/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/unf_ext-0.0.7.6:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/diff-lcs-1.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/coveralls-0.8.23/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/thor-0.20.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/term-ansicolor-1.7.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/tins-1.20.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-0.16.1/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/simplecov-html-0.10.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/docile-1.3.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/json-2.2.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/extensions/universal-darwin-18/2.3.0/json-2.2.0:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/connection_pool-2.2.2/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/backports-3.15.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/ast-2.4.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/activesupport-5.2.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/tzinfo-1.2.5/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/thread_safe-0.3.6/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/minitest-5.11.3/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/i18n-1.6.0/lib:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/vendor/bundle/bundler/../ruby/2.3.0/gems/concurrent-ruby-1.1.5/lib:/Library/Ruby/Site/2.3.0:/Library/Ruby/Site/2.3.0/x86_64-darwin18:/Library/Ruby/Site/2.3.0/universal-darwin18:/Library/Ruby/Site:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0/x86_64-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby/2.3.0/universal-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/vendor_ruby:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/x86_64-darwin18:/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/universal-darwin18:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew -- /Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/build.rb /Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Taps/staticfloat/homebrew-juliatranslated/libgfortran.rb --ignore-dependencies --verbose
==> Downloading https://github.com/staticfloat/homebrew-libgfortran-formula/archive/master.tar.gz
==> Downloading from https://codeload.github.com/staticfloat/homebrew-libgfortran-formula/tar.gz/master
/usr/bin/curl -q --show-error --user-agent Homebrew/2.1.7\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.14.5\)\ curl/7.54.0 --fail --location --remote-time --continue-at 0 --output /Users/jonas/Library/Caches/Homebrew.jl/downloads/3c7bba6199e6596a7715abfe8c0245c4ffbc2c6545516e96ea00190b45bced68--homebrew-libgfortran-formula-master.tar.gz.incomplete https://codeload.github.com/staticfloat/homebrew-libgfortran-formula/tar.gz/master
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   303  100   303    0     0    668      0 --:--:-- --:--:-- --:--:--   668
==> Verifying 3c7bba6199e6596a7715abfe8c0245c4ffbc2c6545516e96ea00190b45bced68--homebrew-libgfortran-formula-master.tar.gz checksum
tar xof /Users/jonas/Library/Caches/Homebrew.jl/downloads/3c7bba6199e6596a7715abfe8c0245c4ffbc2c6545516e96ea00190b45bced68--homebrew-libgfortran-formula-master.tar.gz -C /private/tmp/d20190711-18897-51i7t4
cp -pR /private/tmp/d20190711-18897-51i7t4/homebrew-libgfortran-formula-master/. /private/tmp/libgfortran-20190711-18897-1y2q61r/homebrew-libgfortran-formula-master
chmod -Rf +w /private/tmp/d20190711-18897-51i7t4
==> cp /Users/jonas/.julia/dev/Homebrew/deps/usr/Cellar/gcc/9.1.0/lib/gcc/9/libquadmath.0.dylib /Users/jonas/.julia/dev/Homebrew/deps/usr/Cellar/libgfortran/7.2/lib
cp: /Users/jonas/.julia/dev/Homebrew/deps/usr/Cellar/gcc/9.1.0/lib/gcc/9/libquadmath.0.dylib: No such file or directory

==> Formula
Tap: staticfloat/juliatranslated
Path: /Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Taps/staticfloat/homebrew-juliatranslated/libgfortran.rb
==> Configuration
HOMEBREW_VERSION: 2.1.7
ORIGIN: https://github.com/Homebrew/brew
HEAD: 2b83463091513826127c14acae81a7c354dfce69
Last commit: 3 days ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 276f23ac9300aa086a1af8e2b8935f146657323b
Core tap last commit: 9 hours ago
HOMEBREW_PREFIX: /Users/jonas/.julia/dev/Homebrew/deps/usr
HOMEBREW_CELLAR: /Users/jonas/.julia/dev/Homebrew/deps/usr/Cellar
HOMEBREW_CACHE: /Users/jonas/Library/Caches/Homebrew.jl/
HOMEBREW_REPOSITORY: /Users/jonas/.julia/dev/Homebrew/deps/usr
HOMEBREW_NO_ANALYTICS: 1
HOMEBREW_NO_AUTO_UPDATE: 1
HOMEBREW_NO_ENV_FILTERING: 1
CPU: octa-core 64-bit kabylake
Homebrew Ruby: 2.3.7 => /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/ruby
Clang: 10.0 build 1001
Git: 2.22.0 => /Users/jonas/.julia/dev/Homebrew/deps/usr/bin/git
Curl: 7.54.0 => /usr/bin/curl
macOS: 10.14.5-x86_64
CLT: 11.0.0.0.1.1559496560
Xcode: 10.2.1
CLT headers: 11.0.0.0.1.1559496560
XQuartz: 2.7.11 => /opt/X11
==> ENV
HOMEBREW_CC: clang
HOMEBREW_CXX: clang++
MAKEFLAGS: -j8
CMAKE_PREFIX_PATH: /Users/jonas/.julia/dev/Homebrew/deps/usr
CMAKE_INCLUDE_PATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/libxml2:/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers
CMAKE_LIBRARY_PATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries
PKG_CONFIG_LIBDIR: /usr/lib/pkgconfig:/Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/os/mac/pkgconfig/10.14
HOMEBREW_GIT: git
HOMEBREW_SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
ACLOCAL_PATH: /Users/jonas/.julia/dev/Homebrew/deps/usr/share/aclocal
PATH: /Users/jonas/.julia/dev/Homebrew/deps/usr/Library/Homebrew/shims/mac/super:/usr/bin:/bin:/usr/sbin:/sbin

Error: staticfloat/juliatranslated/libgfortran 7.2 did not build
Logs:
     /Users/jonas/Library/Logs/Homebrew/libgfortran/00.options.out
     /Users/jonas/Library/Logs/Homebrew/libgfortran/01.cp
Do not report this issue to Homebrew/brew or Homebrew/core!

ERROR: LoadError: failed process: Process(`/Users/jonas/.julia/dev/Homebrew/deps/usr/bin/brew install --ignore-dependencies staticfloat/juliatranslated/libgfortran --verbose`, ProcessExited(1)) [1]
Stacktrace:
 [1] error(::String, ::Base.Process, ::String, ::Int64, ::String) at ./error.jl:42
 [2] pipeline_error at ./process.jl:785 [inlined]
 [3] #run#515(::Bool, ::Function, ::Cmd) at ./process.jl:726
 [4] run at ./process.jl:724 [inlined]
 [5] #brew#4(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Function, ::Cmd) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:19
 [6] #brew at ./none:0 [inlined]
 [7] #install_and_link#38(::Bool, ::Function, ::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:492
 [8] (::getfield(Homebrew, Symbol("#kw##install_and_link")))(::NamedTuple{(:verbose,),Tuple{Bool}}, ::typeof(Homebrew.install_and_link), ::String) at ./none:0
 [9] #add#29(::Bool, ::Bool, ::Function, ::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:462
 [10] (::getfield(Homebrew, Symbol("#kw##add")))(::NamedTuple{(:verbose,),Tuple{Bool}}, ::typeof(Homebrew.add), ::String) at ./none:0
 [11] top-level scope at none:0
 [12] include at ./boot.jl:326 [inlined]
 [13] include_relative(::Module, ::String) at ./loading.jl:1038
 [14] include(::Module, ::String) at ./sysimg.jl:29
 [15] include(::String) at ./client.jl:403
 [16] top-level scope at none:0
in expression starting at /Users/jonas/.julia/dev/Homebrew/test/runtests.jl:95
ERROR: Package Homebrew errored during testing
```

However, testing `master` also fails for me:
```
(v1.1) pkg> test Homebrew
...
[ Info: pkg-config: 0.29.2 installed to: /Users/jonas/.julia/dev/Homebrew/deps/usr/Cellar/pkg-config/0.29.2
Error: glib: undefined method `uses_from_macos' for Formulary::FormulaNamespaceca12f25990f4d05aca6c5239da792f5c::Glib:Class
ERROR: LoadError: ArgumentError: `brew info` failed for ["cairo", "fontconfig", "fribidi", "glib", "harfbuzz"]!
Stacktrace:
 [1] json(::Array{String,1}) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:192
 [2] info(::Array{String,1}) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:229
 [3] #direct_deps#10(::Bool, ::Function, ::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:285
 [4] #direct_deps at ./none:0 [inlined]
 [5] #deps_tree#17(::Bool, ::Function, ::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:306
 [6] #deps_tree at ./none:0 [inlined]
 [7] #deps_sorted#24(::Bool, ::Function, ::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:379
 [8] deps_sorted(::String) at /Users/jonas/.julia/dev/Homebrew/src/API.jl:379
 [9] top-level scope at none:0
 [10] include at ./boot.jl:326 [inlined]
 [11] include_relative(::Module, ::String) at ./loading.jl:1038
 [12] include(::Module, ::String) at ./sysimg.jl:29
 [13] include(::String) at ./client.jl:403
 [14] top-level scope at none:0
in expression starting at /Users/jonas/.julia/dev/Homebrew/test/runtests.jl:53
ERROR: Package Homebrew errored during testing
```

It looks like `brew` is exiting with a error code much more often now. Other warning reported by `brew` (I don't know whether that's relevant):
```
Warning: --ignore-dependencies is an unsupported Homebrew developer flag!
Adjust your PATH to put any preferred versions of applications earlier in the
PATH rather than using this unsupported flag!
```