### PR TITLE
Added Catalina in version list.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -641,7 +641,8 @@ function osx_version_string()
         "10.11" => "el_capitan",
         "10.12" => "sierra",
         "10.13" => "high_sierra",
-        "10.14" => "mojave"
+        "10.14" => "mojave",
+        "10.15" => "catalina"
     )[OSX_VERSION[1]]
 end
 

--- a/src/private_API.jl
+++ b/src/private_API.jl
@@ -15,8 +15,7 @@ const auto_tappath = joinpath(brew_prefix,"Library","Taps","staticfloat","homebr
 # Where we download brew from
 const BREW_URL = "https://github.com/Homebrew/brew"
 const BREW_BRANCH = "master"
-const BREW_STABLE_SHA = "2b83463091513826127c14acae81a7c354dfce69"
-
+const BREW_STABLE_SHA = "85e4013989e849b374ff40858969be1125d63370"
 """
 `install_brew()`
 


### PR DESCRIPTION
Updated SHA stable to minimum version that makes Homebrew work with Ruby 2.6, which is needed for brew to work on macOs Catalina. Would fix https://github.com/JuliaPackaging/Homebrew.jl/issues/266

@staticfloat 

