### PR TITLE
Version update.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Homebrew"
 uuid = "d9be37ee-ecc9-5288-90f1-b9ca67657a75"
 authors = ["staticfloat@gmail.com <staticfloat@gmail.com>"]
-version = "0.6.4"
+version = "0.7.2"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"


### PR DESCRIPTION
It seems that version 0.7.2 does not correctly set its version leading to upstream errors, e.g. in LRSLib. This minimal PR corrects the version so packages with dependencies to upstream projects that still use Homebrew can be properly upgraded. For instance, `up Polyhedra LRSLib Homebrew` failed for me before applying this change.

Tested with download 0.7.2 release - I assume that the code in there is identical to master. If not, please let me know, so I can adapt the fix.

@staticfloat

When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.
